### PR TITLE
Add pointers to first three of four PacBio raw data

### DIFF
--- a/data/PacBio_runs.csv
+++ b/data/PacBio_runs.csv
@@ -1,1 +1,4 @@
 library,run,subreads
+lib1,200415_A,/fh/fast/bloom_j/SR/ngs/pacbio/200415_TylerStarr/r54228_20200414_180011/1_A01/m54228_200414_185350.subreads.bam
+lib1,200415_B,/fh/fast/bloom_j/SR/ngs/pacbio/200415_TylerStarr/r54228_20200414_180011/2_B01/m54228_200415_152345.subreads.bam
+lib2,200415_A,/fh/fast/bloom_j/SR/ngs/pacbio/200415_TylerStarr/r54228_20200414_180011/3_C01/m54228_200416_115520.subreads.bam


### PR DESCRIPTION
The sequencing core let us know that three of the four cells data have completed and are uploaded. The fourth (a second cell for lib2) will be added ~tomorrow morning. I thought to point to the first three and make this PR now, feel free to reject until the fourth one is in place if that is easiest