### PR TITLE
fixed typo to structures file

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -20,7 +20,7 @@
 
 title: SARS-CoV-2 RBD DMS
 description: >- # this means to ignore newlines until "baseurl:"
-  here is where we could add a link to the github
+  
 baseurl: "/SARS-CoV-2-RBD_DMS" # the subpath of your site, e.g. /blog
 url: "" # the base hostname & protocol for your site, e.g. http://example.com
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,5 +10,5 @@ layout: default
 - Select site subsets using the drop down menu below the plots.
 - Change which sites are displayed by brushing the zoom bar and dragging the brush.
 - Clear the zoom bar by double clicking it.
-- Structural visualizations of the data are available via `dms-view` [here](https://jbloomlab.github.io/SARS-CoV-2-RBD-DMS/structures) 
+- Structural visualizations of the data are available via `dms-view` [here](https://jbloomlab.github.io/SARS-CoV-2-RBD_DMS/structures) 
 - Raw data available [on GitHub](https://github.com/jbloomlab/SARS-CoV-2-RBD_DMS/blob/master/results/single_mut_effects/single_mut_effects.csv)


### PR DESCRIPTION
Whoops! In the link from the heatmaps to the structures we had a typo in the url `SARS-CoV-2-RBD-DMS` vs. `SARS-CoV-2-RBD_DMS`

This should fix things.