### PR TITLE
Add fluor boundaries from titration sorts

### DIFF
--- a/compute_binding_Kd.Rmd
+++ b/compute_binding_Kd.Rmd
@@ -90,6 +90,18 @@ samples_lib2 <- data.frame(sample=unique(paste(barcode_runs$sample_type,formatC(
 ## Calculating mean bin for each barcode at each sample concentration
 Next, for each barcode at each of the 16 ACE2 concentrations, calculate the "mean bin" response variable. This is calculated as a simple mean, where the value of each bin is the integer value of the bin (bin1=unbound, bin4=highly bound) -- because of how bins are defined, the mean fluorescence of cells in each bin are equally spaced on a log-normal scale, so mean bin correlates with simple mean fluorescence.
 
+We do not use the fluorescence boundaries of the FACS bins in our calculations here, but we provide them for posterity's sake below. For the library 1 titration sorts, the fluorescence boundaries for bins 1-4 are as follows:
+
+```
+(-266, 165), (166, 1315), (1316, 10516), (10517, 262143)
+```
+
+For the library 2 titration sorts, the fluorescence boundaries for bins 1-4 are as follows:
+
+```
+(-288, 163), (164, 1303), (1304, 10603), (10604, 262143)
+```
+
 ```{r calculate_mean_bin}
 #function that returns mean bin and sum of counts for four bins cell counts
 calc.meanbin <- function(vec){return( list((vec[1]*1+vec[2]*2+vec[3]*3+vec[4]*4)/(vec[1]+vec[2]+vec[3]+vec[4]),

--- a/results/summary/compute_binding_Kd.md
+++ b/results/summary/compute_binding_Kd.md
@@ -153,6 +153,18 @@ where the value of each bin is the integer value of the bin
 mean fluorescence of cells in each bin are equally spaced on a
 log-normal scale, so mean bin correlates with simple mean fluorescence.
 
+We do not use the fluorescence boundaries of the FACS bins in our calculations here, but we provide them for posterity's sake below. For the library 1 titration sorts, the fluorescence boundaries for bins 1-4 are as follows:
+
+```
+(-266, 165), (166, 1315), (1316, 10516), (10517, 262143)
+```
+
+For the library 2 titration sorts, the fluorescence boundaries for bins 1-4 are as follows:
+
+```
+(-288, 163), (164, 1303), (1304, 10603), (10604, 262143)
+```
+
 ``` r
 #function that returns mean bin and sum of counts for four bins cell counts
 calc.meanbin <- function(vec){return( list((vec[1]*1+vec[2]*2+vec[3]*3+vec[4]*4)/(vec[1]+vec[2]+vec[3]+vec[4]),


### PR DESCRIPTION
This PR adds in text indicating the fluorescence boundaries that were set in the titraion FACS experiments. We do not use them in our calculation of mean bin that we use in the titration fits, but there is good reason that others who might want to reanalyze our data will need this information.